### PR TITLE
alias #random with #sample

### DIFF
--- a/lib/randumb/relation.rb
+++ b/lib/randumb/relation.rb
@@ -29,9 +29,9 @@ module Randumb
           # keep prior orders and append random
           all_orders = (relation.orders + [order_clause]).join(", ")
           # override all previous orders
-          relation.reorder(all_orders) 
+          relation.reorder(all_orders)
         end
-        
+
         # override the limit if they are requesting multiple records
         if max_items && (!relation.limit_value || relation.limit_value > max_items)
           the_scope = the_scope.limit(max_items)
@@ -144,6 +144,7 @@ module Randumb
       def random(max_items = nil)
         relation.random(max_items)
       end
+      alias sample random
 
       def random_weighted(ranking_column, max_items = nil)
         relation.random_weighted(ranking_column, max_items)

--- a/test/randumb_test.rb
+++ b/test/randumb_test.rb
@@ -7,6 +7,9 @@ class RandumbTest < Test::Unit::TestCase
     assert_equal expected, obj.send(:random_by_id_shuffle, params), "when calling random_by_id_shuffle"
   end
 
+  should "should alias #random as #sample" do
+    assert Artist.respond_to?(:sample)
+  end
 
   should "should return empty when no record in table" do
     assert_equal 0, Artist.count


### PR DESCRIPTION
# sample is the method that picks random elements from arrays in the ruby standard library, so having the same method name here seems a nice way to be consistent with ruby names.

Hope you find this useful 

Andrea
