### PR TITLE
attempting to fix some issues caused by new version of minitest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ env:
   - DB=postgres ACTIVE_RECORD_VERSION=3.2.13
   - DB=mysql ACTIVE_RECORD_VERSION=3.2.13
   - DB=sqlite3 ACTIVE_RECORD_VERSION=3.2.13
+
+# most recent 4.0.x
+  - DB=postgres ACTIVE_RECORD_VERSION=4.0.9
+  - DB=mysql ACTIVE_RECORD_VERSION=4.0.9
+  - DB=sqlite3 ACTIVE_RECORD_VERSION=4.0.9
+
 # active record 4 and whatever is latest
   - DB=postgres ACTIVE_RECORD_VERSION=latest
   - DB=mysql ACTIVE_RECORD_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,6 @@ env:
   - DB=mysql ACTIVE_RECORD_VERSION=3.2.13
   - DB=sqlite3 ACTIVE_RECORD_VERSION=3.2.13
 
-# most recent 4.0.x
-  - DB=postgres ACTIVE_RECORD_VERSION=4.0.9
-  - DB=mysql ACTIVE_RECORD_VERSION=4.0.9
-  - DB=sqlite3 ACTIVE_RECORD_VERSION=4.0.9
-
 # active record 4 and whatever is latest
   - DB=postgres ACTIVE_RECORD_VERSION=latest
   - DB=mysql ACTIVE_RECORD_VERSION=latest

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,6 @@ task :default => [:test]
 
 desc "Run unit tests."
 task :test do
-  ruby "test/randumb_test.rb"
-  ruby "test/weighted_test.rb"
+  ruby "test/test_randumb.rb"
+  ruby "test/test_weighted.rb"
 end

--- a/lib/randumb/relation.rb
+++ b/lib/randumb/relation.rb
@@ -57,7 +57,7 @@ module Randumb
         # get the records and shuffle since the order of the ids
         # passed to where() isn't retained in the result set
         rng = random_number_generator(opts)
-        records = the_scope.where(:id => ids).shuffle!(:random => rng)
+        records = the_scope.where(:id => ids).to_a.shuffle!(:random => rng)
 
         # return first record if method was called without parameters
         return_first_record ? records.first : records

--- a/randumb.gemspec
+++ b/randumb.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler', ['>= 1.0.0']
   s.add_development_dependency 'rake', ['>= 0']
+  s.add_development_dependency 'minitest', ['>= 5.4.1']
   s.add_development_dependency "shoulda"
   s.add_development_dependency "factory_girl", "~> 3.0"
   s.add_development_dependency "faker"

--- a/randumb.gemspec
+++ b/randumb.gemspec
@@ -13,11 +13,9 @@ Gem::Specification.new do |s|
   s.files       = Dir['lib/**/*.rb']
   s.test_files  = Dir['test/**/*.rb']
 
-  s.add_dependency 'rake'
-
   # need to test different versions of active record
   ar_env = ENV['ACTIVE_RECORD_VERSION'] || '>= 3.0.0'
-  ar_env = ">= 4.0.0" if ar_env == 'latest'
+  ar_env = ">= 4.1.0" if ar_env == 'latest'
   s.add_dependency 'activesupport', ar_env
   s.add_dependency 'activerecord', ar_env
 
@@ -36,6 +34,8 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'pg'
   end
 
+  s.add_development_dependency 'bundler', ['>= 1.0.0']
+  s.add_development_dependency 'rake', ['>= 0']
   s.add_development_dependency "shoulda"
   s.add_development_dependency "factory_girl", "~> 3.0"
   s.add_development_dependency "faker"

--- a/randumb.gemspec
+++ b/randumb.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler', ['>= 1.0.0']
   s.add_development_dependency 'rake', ['>= 0']
-  s.add_development_dependency 'minitest', ['>= 5.4.1']
+  s.add_development_dependency 'minitest', ['>= 4.0.0']
   s.add_development_dependency "shoulda"
   s.add_development_dependency "factory_girl", "~> 3.0"
   s.add_development_dependency "faker"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,5 @@
 $LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
 require 'rubygems'
-require 'test/unit'
 require 'shoulda'
 require 'factory_girl'
 require 'faker'
@@ -47,10 +46,10 @@ dep = defined?(ActiveSupport::Dependencies) ? ActiveSupport::Dependencies : ::De
 dep.autoload_paths.unshift MODELS_PATH
 
 # load factories now
-require 'test/models/factories'
+require_relative 'models/factories'
 
 # clear db for every test
-class Test::Unit::TestCase
+class Minitest::Test
 
   def setup
     Artist.delete_all

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
 require 'rubygems'
+require 'minitest/autorun'
 require 'shoulda'
 require 'factory_girl'
 require 'faker'

--- a/test/test_randumb.rb
+++ b/test/test_randumb.rb
@@ -1,6 +1,7 @@
-$:.unshift '.'; require File.dirname(__FILE__) + '/test_helper'
+require "minitest/autorun"
+require_relative "helper"
 
-class RandumbTest < Test::Unit::TestCase
+class TestRandumb < Minitest::Test
 
   def assert_equal_for_both_methods(expected, obj, *params)
     assert_equal expected, obj.send(:random, *params), "when calling random"
@@ -69,15 +70,15 @@ class RandumbTest < Test::Unit::TestCase
 
         artists = Artist.select(:name).random(3)
         assert_equal false, artists.first.name.nil?
-        assert_raise (ActiveModel::MissingAttributeError) {artists.first.views}
+        assert_raises (ActiveModel::MissingAttributeError) {artists.first.views}
 
         artists = Artist.select(:name).order_by_rand.limit(3)
         assert_equal false, artists.first.name.nil?
-        assert_raise (ActiveModel::MissingAttributeError) {artists.first.views}
+        assert_raises (ActiveModel::MissingAttributeError) {artists.first.views}
 
         artists = Artist.select(:name).random_by_id_shuffle(3)
         assert_equal false, artists.first.name.nil?
-        assert_raise (ActiveModel::MissingAttributeError) {artists.first.views}
+        assert_raises (ActiveModel::MissingAttributeError) {artists.first.views}
       end
 
       should "respect scopes" do
@@ -153,8 +154,8 @@ class RandumbTest < Test::Unit::TestCase
           should "work with uniq" do
             assert_equal 2, Artist.uniq.random(2).length
             assert_equal 2, Artist.uniq.random_by_id_shuffle(2).length
-            assert_not_nil Artist.uniq.random
-            assert_not_nil Artist.uniq.random_by_id_shuffle
+            assert Artist.uniq.random
+            assert Artist.uniq.random_by_id_shuffle
           end
         end
 

--- a/test/test_weighted.rb
+++ b/test/test_weighted.rb
@@ -1,6 +1,7 @@
-$:.unshift '.'; require File.dirname(__FILE__) + '/test_helper'
+require "minitest/autorun"
+require_relative "helper"
 
-class WeightedTest < Test::Unit::TestCase
+class TestWeighted < Minitest::Test
 
   should "raise exception when called with a non-existent column" do
     assert_raises(ArgumentError) do


### PR DESCRIPTION
Thanks to https://github.com/spilliton/randumb/pull/28 for bringing this to my attention.  Running ```rake``` seems to work now.  Also breaking up travis active record tests into 4.0.x and latest (currently 4.1.5