### PR TITLE
Return orders as an array instead of a string

### DIFF
--- a/lib/randumb/relation.rb
+++ b/lib/randumb/relation.rb
@@ -89,7 +89,7 @@ module Randumb
           order(order_clause)
         else
           # keep prior orders and append random
-          all_orders = (orders + [order_clause]).join(", ")
+          all_orders = (orders + [order_clause])
           # override all previous orders
           reorder(all_orders)
         end


### PR DESCRIPTION
Joining the order clauses caused non-string clauses (Arel nodes) to be appended as a string : 
````
Model.order(featured: :desc).order_by_rand(seed: session[:order_seed])
=>
[...] ORDER BY #<Arel::Nodes::Descending:0x007fe60af66858>, (SUBSTR(businesses.id * 0.5488135039273248, LENGTH(businesses.id) + 2)) LIMIT 12 OFFSET 0
````
