### PR TITLE
Fix delegate method issue

### DIFF
--- a/test/models/factories.rb
+++ b/test/models/factories.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :artist do
-    name { Faker::Lorem.words(3).join(' ') }
+    name { Faker::Lorem.words(number: 3).join(' ') }
     views  { Random.rand(50) }
     rating { Random.rand(100) / 100 }
   end


### PR DESCRIPTION
delegating methods to arel is deprecated in Rails 6.0, so
when I use `.order_by_rand`
```
     NameError:
       undefined local variable or method `orders' for #<ActiveRecord::Relation []>
       Did you mean?  order
                      order!
```